### PR TITLE
Fix image url

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -22,7 +22,7 @@
         "DisplayVersionOnlyInInstallerView": false,
         "force_down": false,
         "links": {
-            "image": "https://raw.githubusercontent.com/PsychoticNM/Wild-Card-FNV/main/TTW.png",
+            "image": "https://raw.githubusercontent.com/PsychoticNM/Wild-Card-TTW/main/TTW.png",
             "readme": "https://www.nexusmods.com/newvegas/mods/85177?tab=description",
             "download": "https://authored-files.wabbajack.org/Wild Card TTW.wabbajack_6c295d21-329a-4bd3-bb33-c53a9171cd27",
             "machineURL": "WildCardTTW",


### PR DESCRIPTION
Your image url references a TTW.png in your FNV repo.
Changed it to the TTW repo.